### PR TITLE
Resolve database primary key and LDAP identifier conflicts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 Active Directory LDAP Authentication
-=========
+====================================
 
 Laravel 4 Active Directory LDAP Authentication driver.
 
 Installation
-============
-
+------------
 To install this [Active Directory LDAP Authentication](https://github.com/ccovey/ldap-auth) fork in your application, add the following to your `composer.json` file
 
 ```json
@@ -44,7 +43,7 @@ This tells Laravel 4 to use the service provider from the vendor folder.
 You also need to direct Auth to use the ldap driver instead of Eloquent or Database, edit `config/auth.php` and change driver to `ldap`
 
 Configuration
-=============
+-------------
 To specify the username field to be used in `app/config/auth.php` set a key / value pair `'username_field' => 'fieldname'` This will default to `username` if you don't provide one.
 
 To set up your adLDAP for connections to your domain controller, create a file app/config/adldap.php This will provide all the configuration values for your connection. For all configuration options an array like the one below should be provided.
@@ -73,8 +72,7 @@ return array(
 ```
 
 Usage
-======
-
+-----
 $guarded is now defaulted to all so to use a model you must change to `$guarded = array()`. If you store Roles or similar sensitive information make sure that you add that to the guarded array.
 
 Use of `Auth` is the same as with the default service provider.
@@ -88,6 +86,5 @@ For more information on what fields from AD are available to you visit http://go
 You may also get a complete user list for a specific OU by defining the `userList` key and setting it to `true`. You must also set the `group` key that defined which OU to look at. Do not that on a large AD this may slow down the application.
 
 Model Usage
-===========
-
+-----------
 You can still use a model with this implementation as well if you want. ldap-auth will take your fields from ldap and attach them to the model allowing you to access things such as roles / permissions from the model if the account is valid in Active Directory. It is also important to note that no authentication takes place off of the model. All authentication is done from Active Directory and if they are removed from AD but still in a users table they WILL NOT be able to log in.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,31 @@
 Active Directory LDAP Authentication
 =========
 
-Laravel 4 Active Directory LDAP Authentication driver. 
+Laravel 4 Active Directory LDAP Authentication driver.
 
 Installation
 ============
 
-To install this in your application add the following to your `composer.json` file
+To install this [Active Directory LDAP Authentication](https://github.com/ccovey/ldap-auth) fork in your application, add the following to your `composer.json` file
 
 ```json
-require {
-	"ccovey/ldap-auth": "1.0.x",
+{
+  ...
+  "require": {
+    "laravel/framework": "4.*",
+    ...
+    "ccovey/ldap-auth": "dev-patch-1",
+  },
+  ...
+  "repositories": [{
+    "type": "vcs",
+    "url": "https://github.com/tortuetorche/ldap-auth"
+  }],
+  ...
 }
 ```
 
-Then run 
+Then run
 
 `composer install` or `composer update` as appropriate
 
@@ -34,6 +45,8 @@ You also need to direct Auth to use the ldap driver instead of Eloquent or Datab
 
 Configuration
 =============
+To specify the username field to be used in `app/config/auth.php` set a key / value pair `'username_field' => 'fieldname'` This will default to `username` if you don't provide one.
+
 To set up your adLDAP for connections to your domain controller, create a file app/config/adldap.php This will provide all the configuration values for your connection. For all configuration options an array like the one below should be provided.
 
 It is important to note that the only required options are `account_suffix`, `base_dn`, and `domain_controllers`The others provide either security or more information. If you don't want to use the others simply delete them.

--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,22 @@
 {
     "name": "ccovey/ldap-auth",
     "description": "",
-    "keywords": ["laravel", "L4", "LDAP", "Authentication", "Laravel 4"],
+    "keywords": ["laravel", "L4", "LDAP", "Authentication", "Laravel 4", "Laravel 4.1"],
     "authors": [
         {
             "name": "Cody Covey",
             "email": "ccovey14@gmail.com"
+        },
+        {
+            "name": "Tortue Torche",
+            "email": "tortuetorche@spam.me"
         }
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.0.x",
-        "illuminate/auth": "4.0.x",
-        "illuminate/config": "4.0.x",
+        "illuminate/support": "4.*",
+        "illuminate/auth": "4.*",
+        "illuminate/config": "4.*",
         "adLdap/adLdap": "4.x-dev"
     },
     "require-dev": {

--- a/src/Ccovey/LdapAuth/LdapAuthManager.php
+++ b/src/Ccovey/LdapAuth/LdapAuthManager.php
@@ -18,7 +18,7 @@ class LdapAuthManager extends AuthManager
     {
         $provider = $this->createLdapProvider();
         
-        return new Guard($provider, $this->app['session']);
+        return new Guard($provider, $this->app['session.store']);
     }
     
     /**

--- a/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
+++ b/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
@@ -77,7 +77,6 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
      */
     public function retrieveByCredentials(array $credentials)
     {
-        // \Log::warning(json_encode($credentials));//debug
         if ($this->model) {
             $query = $this->createModel()->newQuery();
 
@@ -87,7 +86,6 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
             }
 
             $model = $query->first();
-            // \Log::warning($model->$identifierField);//debug
             if($model) {
                 return $this->retrieveByID($model->getKey(), $model->{$this->getUsernameField()});
             }

--- a/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
+++ b/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
@@ -203,6 +203,9 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
     {
         $grps = '';
         if ( ! is_null($groups) ) {
+            if (!is_array($groups)) {
+                $groups = explode(',', $groups);
+            }
             foreach ($groups as $k => $group) {
                 $splitGroups = explode(',', $group);
                 foreach ($splitGroups as $splitGroup) {

--- a/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
+++ b/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
@@ -177,7 +177,7 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
      */
     protected function addLdapToModel($model, $ldap)
     {
-        $combined = $model->getAttributes() + $ldap;
+        $combined = $ldap + $model->getAttributes();
 
         return $model->fill($combined);
     }

--- a/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
+++ b/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
@@ -39,23 +39,27 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
     }
 
     /**
-     * Retrieve a user by their unique idenetifier.
+     * Retrieve a user by their unique identifier.
      *
      * @param  mixed  $identifier
+     * @param  mixed  $ldapIdentifier; default to null
      * @return Illuminate\Auth\GenericUser|null
      */
-    public function retrieveByID($identifier)
+    public function retrieveByID($identifier, $ldapIdentifier = null)
     {
+        if( is_null($ldapIdentifier) ) {
+            $ldapIdentifier = $identifier;
+        }
         $ldapUserInfo = null;
-        
-        $infoCollection = $this->ad->user()->infoCollection($identifier, array('*') );
+
+        $infoCollection = $this->ad->user()->infoCollection($ldapIdentifier, array('*') );
 
         if ( $infoCollection ) {
             $ldapUserInfo = $this->setInfoArray($infoCollection);
 
             if ($this->model) {
-                $model = $this->createModel()->newQuery()->find($identifier);
-                
+                $model = $this->createModel()->newQuery()->where($this->getUsernameField(), $identifier)->first();
+
                 if ( ! is_null($model) ) {
                     return $this->addLdapToModel($model, $ldapUserInfo);
                 }
@@ -73,7 +77,30 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
      */
     public function retrieveByCredentials(array $credentials)
     {
-        return $this->retrieveByID($credentials['username']);
+        // \Log::warning(json_encode($credentials));//debug
+        if ($this->model) {
+            $query = $this->createModel()->newQuery();
+
+            foreach ($credentials as $key => $value)
+            {
+                if ( ! str_contains($key, 'password')) $query->where($key, $value);
+            }
+
+            $model = $query->first();
+            // \Log::warning($model->$identifierField);//debug
+            if($model) {
+                return $this->retrieveByID($model->getKey(), $model->{$this->getUsernameField()});
+            }
+        }
+        return $this->retrieveByID( $credentials[$this->getUsernameField()] );
+    }
+
+    /**
+     * @return string
+     */
+    public function getUsernameField()
+    {
+        return (\Config::has('auth.username_field')) ? \Config::get('auth.username_field') : 'username';
     }
 
     /**


### PR DESCRIPTION
This pull request add two type of identifiers. One for your database model and one for your LDAP model.

Usually the LDAP identifier is the `username` attribute, string/varchar datatype.
And the Database identifier is the primary key of your table (`id` column by default), integer datatype.

This feature is really useful when you need to add some relations to your User model (E.g. attaching roles).
Because it allows to avoid conflicts between this two type of identifiers.

Otherwise, when you login with a new user it's OK, but when a user already exists in the database, it's not working.
Because Laravel call the `retrieveByID($identifier)` method with the `id` attribute of the user.
So it can find the user because the`retrieveByID($identifier)` method want a `username` value.
