### PR TITLE
Use session.store instead of session for Guard instance.

### DIFF
--- a/src/Ccovey/LdapAuth/LdapAuthManager.php
+++ b/src/Ccovey/LdapAuth/LdapAuthManager.php
@@ -18,7 +18,7 @@ class LdapAuthManager extends AuthManager
     {
         $provider = $this->createLdapProvider();
         
-        return new Guard($provider, $this->app['session']);
+        return new Guard($provider, $this->app['session.store']);
     }
     
     /**


### PR DESCRIPTION
On September 30, commit 3816e425ae3fdaa69474763737d5e906e073c9a9 to
the Laravel framework changed the arguments of the Guard constructor,
so it now takes a Store object instead of a Session object. This one
line patch fixes the issue.
