### PR TITLE
Default username_field to username if not set

### DIFF
--- a/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
+++ b/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
@@ -222,6 +222,6 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
 
     protected function getUsernameField()
     {
-        return $this->config['username_field'];
+        return isset($this->config['username_field'])?$this->config['username_field']:'username';
     }
 }


### PR DESCRIPTION
We didn't have a username_field defined in app/config/auth.php and kept getting an error preventing the authentication from working, would it be beneficial to add a default username_field to LdapAuthUserProvider.php ?
