### PR TITLE
fixed getAllGroups from returning OUs as groups.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.x",
-        "illuminate/auth": "4.1.x",
-        "illuminate/config": "4.1.x",
+        "illuminate/support": "4.2.x",
+        "illuminate/auth": "4.2.x",
+        "illuminate/config": "4.2.x",
         "adldap/adldap": "4.0.x"
     },
     "require-dev": {

--- a/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
+++ b/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
@@ -66,6 +66,24 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
     }
 
     /**
+     * Retrieve a user by by their unique identifier and "remember me" token.
+     *
+     * @param  mixed  $identifier
+     * @param  string  $token
+     * @return \Illuminate\Auth\UserInterface|null
+     */
+    public function retrieveByToken($identifier, $token){}
+
+    /**
+     * Update the "remember me" token for the given user in storage.
+     *
+     * @param  \Illuminate\Auth\UserInterface  $user
+     * @param  string  $token
+     * @return void
+     */
+    public function updateRememberToken(Auth\UserInterface $user, $token){}
+
+    /**
      * Retrieve a user by the given credentials.
      *
      * @param  array  $credentials

--- a/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
+++ b/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
@@ -197,18 +197,14 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
      */
     protected function getAllGroups($groups) 
     {
-        $grps = '';
+        $grps = array();
         if ( ! is_null($groups) ) {
             if (!is_array($groups)) {
                 $groups = explode(',', $groups);
             }
             foreach ($groups as $k => $group) {
                 $splitGroups = explode(',', $group);
-                foreach ($splitGroups as $splitGroup) {
-                    if (substr($splitGroup,0, 3) !== 'DC=') {
-                        $grps[substr($splitGroup, '3')] = substr($splitGroup, '3');
-                    }
-                }
+                $grps[substr($splitGroups[0], 3)] = substr($splitGroups[0], 3);
             }
         }
 

--- a/src/Ccovey/LdapAuth/LdapUser.php
+++ b/src/Ccovey/LdapAuth/LdapUser.php
@@ -38,6 +38,28 @@ class LdapUser implements Auth\UserInterface
 	}
 
 	/**
+	 * Get the token value for the "remember me" session.
+	 *
+	 * @return string
+	 */
+	public function getRememberToken(){}
+
+	/**
+	 * Set the token value for the "remember me" session.
+	 *
+	 * @param  string  $value
+	 * @return void
+	 */
+	public function setRememberToken($value){}
+
+	/**
+	 * Get the column name for the "remember me" token.
+	 *
+	 * @return string
+	 */
+	public function getRememberTokenName(){}
+
+	/**
 	 * Dynamically access the user's attributes.
 	 *
 	 * @param  string  $key


### PR DESCRIPTION
removed the loop through the exploded values and just grab the first value as it is always going to be the group's name first after CN=.
