### PR TITLE
Fixed a few bugs with the LdapAuthUserProvider.

### DIFF
--- a/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
+++ b/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
@@ -94,6 +94,9 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
             }
 
             return new LdapUser((array) $ldapUserInfo);
+        } else {
+            // ALWAYS return an LdapUser user, even when we don't have admin access.
+            return new LdapUser((array) $credentials); 
         }
     }
 
@@ -106,7 +109,10 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
      */
     public function validateCredentials(Auth\UserInterface $user, array $credentials)
     {
-        return $this->ad->authenticate($credentials['username'], $credentials['password']);
+        // Make sure we're fetching the username field as set by configuration.
+        $fieldName = $this->getUsernameField();
+
+        return $this->ad->authenticate($credentials[$fieldName], $credentials['password']);
     }
     
     /**


### PR DESCRIPTION
Always return an LdapUser user, even when we don't have admin access; if we don't do this then Auth::attempt will fail. Make sure we're fetching the username field as set by configuration in the validateCredentials method.
