### PR TITLE
Booj

### DIFF
--- a/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
+++ b/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
@@ -94,6 +94,9 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
             }
 
             return new LdapUser((array) $ldapUserInfo);
+        } else {
+            // ALWAYS return an LdapUser user, even when we don't have admin access.
+            return new LdapUser((array) $credentials); 
         }
     }
 
@@ -106,7 +109,10 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
      */
     public function validateCredentials(Auth\UserInterface $user, array $credentials)
     {
-        return $this->ad->authenticate($credentials['username'], $credentials['password']);
+        // Make sure we're fetching the username field as set by configuration.
+        $fieldName = $this->getUsernameField();
+
+        return $this->ad->authenticate($credentials[$fieldName], $credentials['password']);
     }
     
     /**

--- a/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
+++ b/src/Ccovey/LdapAuth/LdapAuthUserProvider.php
@@ -62,6 +62,9 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
             }
 
             return new LdapUser((array) $ldapUserInfo);
+        } else {
+            // ALWAYS return an LdapUser user, even when we don't have admin access.
+            return new LdapUser(array($this->getUsernameField() => $identifier)); 
         }
     }
 
@@ -96,7 +99,7 @@ class LdapAuthUserProvider implements Auth\UserProviderInterface
             return new LdapUser((array) $ldapUserInfo);
         } else {
             // ALWAYS return an LdapUser user, even when we don't have admin access.
-            return new LdapUser((array) $credentials); 
+            return new LdapUser(array($this->getUsernameField() => $user)); 
         }
     }
 


### PR DESCRIPTION
Right now you're not able to login and stay logged in unless you have admin access to active directory. According to the documentation admin access is optional, so the basic login functionality should still function without it. In order to do this we must always return an LdapUser user, even when we don't have admin access, because if we don't do this then Auth::attempt will fail. I also fixed an unrelated bug where we need to make sure we're fetching the username field as set by configuration in the validateCredentials method.
